### PR TITLE
fix: update dependency version because of dependabot warning

### DIFF
--- a/c-sharp/EstateSalesNetPublicApi/packages.config
+++ b/c-sharp/EstateSalesNetPublicApi/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="RestSharp" version="106.0.0" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net452" developmentDependency="true" />
-  <package id="System.Net.Http" version="4.3.3" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net46" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
updating `System.Net.Http` from 4.3.3 to 4.3.4