### PR TITLE
chore: update dependencies (RestSharp and System.Security.Cryptography)

### DIFF
--- a/c-sharp/EstateSalesNetPublicApi/EstateSalesNetPublicApi.csproj
+++ b/c-sharp/EstateSalesNetPublicApi/EstateSalesNetPublicApi.csproj
@@ -106,7 +106,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/c-sharp/EstateSalesNetPublicApi/EstateSalesNetPublicApi.csproj
+++ b/c-sharp/EstateSalesNetPublicApi/EstateSalesNetPublicApi.csproj
@@ -42,8 +42,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.106.0.0\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -58,7 +58,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -70,7 +70,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />

--- a/c-sharp/EstateSalesNetPublicApi/packages.config
+++ b/c-sharp/EstateSalesNetPublicApi/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="106.0.0" targetFramework="net46" />
+  <package id="RestSharp" version="106.15.0" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net452" developmentDependency="true" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net46" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net46" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
**What was updated?**
- restsharp and System.Security.Cryptography dependencies

**What should be tested?**
- good build and api basics

**What else could be affected?**
- nothing

**Are there any infrastructure changes (tasks, services, conversion scripts, machine.config keys, etc)?**
- no